### PR TITLE
add argument section in R regression script

### DIFF
--- a/samtools_regression_somatic_vcf.nf
+++ b/samtools_regression_somatic_vcf.nf
@@ -142,7 +142,7 @@ process R_regression {
  	'''
  	# create a dummy empty pdf to avoid an error in the process when no variant is found 
  	touch !{region_tag}_empty.pdf
-	pileup_nbrr_caller_vcf.r !{region_tag}.vcf !{fasta_ref} !{params.min_qval} !{params.min_dp} !{params.min_ao} !{params.sb_type} !{params.sb_snv} !{params.sb_indel} !{params.all_sites} !{params.do_plots}
+	pileup_nbrr_caller_vcf.r --out_file=!{region_tag}.vcf --fasta_ref=!{fasta_ref} --GQ_threshold=!{params.min_qval} --min_coverage=!{params.min_dp} --min_reads=!{params.min_ao} --SB_type=!{params.sb_type} --SB_threshold_SNV=!{params.sb_snv} --SB_threshold_indel=!{params.sb_indel} --output_all_sites=!{params.all_sites} --do_plots=!{params.do_plots}
 	'''
 }
 PDF.flatten().filter { it.size() == 0 }.subscribe { it.delete() }


### PR DESCRIPTION
add a nice argument section to the R script dedicated to regression. Now a specified order in argument declaration is no longer needed, and passed arguments are in the following form : --argument=value.